### PR TITLE
Show temporary website instead of blog

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -15,7 +15,7 @@ server {
     include /etc/nginx/shared/ssl.conf;
 
     location = / {
-        try_files $uri @blog;
+        try_files $uri @website;
     }
 
     location / {
@@ -24,7 +24,12 @@ server {
         try_files $uri
                   $uri/index.html
                   $uri/
-                  @blog;
+                  @website;
+    }
+
+    location @website {
+        root /var/www/static/website;
+        autoindex on;
     }
 
     location @blog {


### PR DESCRIPTION
The blog has been broken for a few years now. While we work on a new (hopefully simpler) site, this one will serve as a placeholder.

The way I did it there are two possible issues:

* The blog is no longer accessible as far as I can see but I think it's ok
* It's possible to access usp.game.dev.org/website, not sure if that' a problem either