### PR TITLE
Add reverse proxy for bookstack wiki

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -37,6 +37,11 @@ server {
         include /etc/nginx/shared/proxy.conf;
     }
 
+    location /wiki2/ {
+        proxy_pass http://bookstack:8080/;
+        include /etc/nginx/shared/proxy.conf;
+    }
+
     location /wiki/ {
         proxy_pass http://wiki/wiki/;
         include /etc/nginx/shared/proxy.conf;


### PR DESCRIPTION
This is a temporary URL. We'll change it to only `/wiki/` after the old wiki is properly dealt with.