### PR TITLE
Edit websocket configuration

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -79,10 +79,13 @@ server {
     }
 
     location /ws {
-        proxy_pass http://127.0.0.1:4321;
+        proxy_pass http://172.17.0.1:4321;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
         include /etc/nginx/shared/proxy.conf;
-
     }
+
 
     location /metrics {
         auth_basic           "Metrics";


### PR DESCRIPTION
Add proxy configuration to proxy requests from /ws to a websocket server listening on port 4321 in the host (172.17.0.1) (https://dev.to/natterstefan/docker-tip-how-to-get-host-s-ip-address-inside-a-docker-container-5anh)